### PR TITLE
17: Add advanced preference sampling methods

### DIFF
--- a/framework/sampling.py
+++ b/framework/sampling.py
@@ -1,4 +1,5 @@
 import torch
+import numpy as np
 
 from replay_buffer import ReplayBuffer
 from reward_net import RewardNet

--- a/framework/sampling.py
+++ b/framework/sampling.py
@@ -1,0 +1,43 @@
+import torch
+
+from replay_buffer import ReplayBuffer
+from reward_net import RewardNet
+
+
+def uniform_sampling(rb: ReplayBuffer):
+    traj_mb1, traj_mb2 = rb.sample_trajectories()
+    return traj_mb1[0], traj_mb2[0]
+
+
+def disagreement_sampling(rb: ReplayBuffer, reward_net: RewardNet):
+    traj_mb1, traj_mb2 = rb.sample_trajectories()
+
+    disagrees = []
+    with torch.no_grad():
+        for traj_1, traj_2 in zip(traj_mb1, traj_mb2):
+            probs = []
+            for member in range(len(reward_net.ensemble)):
+                probs.append(
+                    reward_net.preference_prob_hat_member(traj_1, traj_2, member)
+                )
+            disagrees.append(np.std(probs, axis=0))
+
+    disagrees_argmax = max(enumerate(disagrees), key=lambda x: x[1])[0]
+    return traj_mb1[disagrees_argmax], traj_mb2[disagrees_argmax]
+
+
+def entropy_sampling(rb: ReplayBuffer, reward_net: RewardNet):
+    traj_mb1, traj_mb2 = rb.sample_trajectories()
+
+    entropies = []
+    with torch.no_grad():
+        for traj_1, traj_2 in zip(traj_mb1, traj_mb2):
+            probs = []
+            for member in range(len(reward_net.ensemble)):
+                probs.append(
+                    reward_net.preference_hat_entropy_member(traj_1, traj_2, member)
+                )
+            entropies.append(np.mean(probs, axis=0))
+
+    entropies_argmax = max(enumerate(entropies), key=lambda x: x[1])[0]
+    return traj_mb1[entropies_argmax], traj_mb2[entropies_argmax]

--- a/framework/unsupervised_exploration.py
+++ b/framework/unsupervised_exploration.py
@@ -55,7 +55,7 @@ class ExplorationRewardKNN:
 
         # Removing NaNs and infinite values in order to ensure the system remains robust
         if not np.all(np.isfinite(intrinsic_rewards)):
-            logging.debug(f"Non-finite intrinsic rewards detected: {intrinsic_rewards}")
+            logging.info(f"Non-finite intrinsic rewards detected: {intrinsic_rewards}")
             intrinsic_rewards = np.nan_to_num(
                 intrinsic_rewards, nan=0.0, posinf=1e6, neginf=-1e6
             )


### PR DESCRIPTION
Fixes issue #17 

What?

- add methods for sampling preferences

How?

- add methods in `sac_rlhf.py`
- change `replay_buffer.sample_trajectories` to sample two lists of `mb_size` many trajectories that have the same length
- add methods to calculate disagreement and entropy in `reward_net.py` (cf. [pebble implementation](https://github.com/rll-research/BPref/blob/main/reward_model.py#L559))


Ready to merge?

- [x] Linter passes
- [x] PR approved