### PR TITLE
90: Fix problem with Reacher and Pusher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: 7.1.1
     hooks:
     -   id: flake8
-        args: ["--ignore=E203,E266,E501,W503"]
+        args: ["--ignore=E203,E266,E402,E501,W503"]
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/framework/evaluation.py
+++ b/framework/evaluation.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 
 import gymnasium as gym
 import imageio
+import matplotlib
+
+matplotlib.use("AGG")
 import numpy as np
 import pandas as pd
 import torch
@@ -20,7 +23,7 @@ from tqdm import trange
 class Args:
     path_to_model: str = ""
     """path to model"""
-    env_id: str = "Hopper-v4"
+    env_id: str = "Hopper-v5"
     """the environment of the policy"""
     seed: int = 1
     """seed of the experiment"""

--- a/framework/sac_rlhf.py
+++ b/framework/sac_rlhf.py
@@ -59,7 +59,7 @@ class Args:
     """the threshold level for the logger to print a message"""
 
     # Algorithm specific arguments
-    env_id: str = "Hopper-v4"
+    env_id: str = "Hopper-v5"
     """the environment id of the task"""
     total_timesteps: int = 1000000
     """total timesteps of the experiments"""
@@ -265,14 +265,24 @@ poetry run pip install "stable_baselines3==2.0.0a1"
     envs.single_observation_space.dtype = np.float32
 
     if is_mujoco_env(envs.envs[0]):
-        qpos = np.zeros(
-            (args.num_envs, envs.envs[0].unwrapped.observation_structure["qpos"]),
-            dtype=np.float32,
-        )
-        qvel = np.zeros(
-            (args.num_envs, envs.envs[0].unwrapped.observation_structure["qvel"]),
-            dtype=np.float32,
-        )
+        try:
+            qpos = np.zeros(
+                (args.num_envs, envs.envs[0].unwrapped.observation_structure["qpos"]),
+                dtype=np.float32,
+            )
+            qvel = np.zeros(
+                (args.num_envs, envs.envs[0].unwrapped.observation_structure["qvel"]),
+                dtype=np.float32,
+            )
+        except AttributeError:
+            qpos = np.zeros(
+                (args.num_envs, envs.envs[0].unwrapped.model.key_qpos.shape[1]),
+                dtype=np.float32,
+            )
+            qvel = np.zeros(
+                (args.num_envs, envs.envs[0].unwrapped.model.key_qvel.shape[1]),
+                dtype=np.float32,
+            )
     else:
         qpos = np.zeros((2, 2))
         qvel = np.zeros((2, 2))
@@ -347,7 +357,7 @@ poetry run pip install "stable_baselines3==2.0.0a1"
                     skipped_qpos = envs.envs[0].unwrapped.observation_structure[
                         "skipped_qpos"
                     ]
-                except KeyError:
+                except (KeyError, AttributeError):
                     skipped_qpos = 0
 
                 for idx in range(args.num_envs):
@@ -543,7 +553,7 @@ poetry run pip install "stable_baselines3==2.0.0a1"
                     skipped_qpos = envs.envs[0].unwrapped.observation_structure[
                         "skipped_qpos"
                     ]
-                except KeyError:
+                except (KeyError, AttributeError):
                     skipped_qpos = 0
 
                 for idx in range(args.num_envs):

--- a/framework/video_recorder.py
+++ b/framework/video_recorder.py
@@ -77,7 +77,11 @@ class VideoRecorder:
                 else qvel_list[0]
             )
             # Append zeros to qpos for skipped qpos values
-            skipped_qpos = env.unwrapped.observation_structure["skipped_qpos"]
+            try:
+                skipped_qpos = env.unwrapped.observation_structure["skipped_qpos"]
+            except (KeyError, AttributeError):
+                skipped_qpos = 0
+
             qpos_extended = np.append(qpos, [0] * skipped_qpos)
 
             env.unwrapped.set_state(qpos_extended, qvel)


### PR DESCRIPTION
**Issue:** #90

**What?**
- for some reason `Pusher-v5` and `Reacher-v5` didn't get the `observation_structure` attribute as all other `-v5` envs
- The `UserWarning: Starting a Matplotlib GUI outside of the main thread will likely fail.` gets an error later

**How?**
- adapt qpos/qvel source to an attribute that those two envs have
- change the matplotlib/nineplot backend to a non-interactive one, for more information see [here](https://matplotlib.org/stable/users/explain/figure/backends.html#the-builtin-backends)
- exclude E402 to make linter not fail for the required line after `import matplotlib`

**Ready to merge to main?**
- [x] Linter passes
- [x] PR Approved